### PR TITLE
audiopolicy: Avoid spurious routing in APM::stopSource

### DIFF
--- a/policy_hal/AudioPolicyManager.cpp
+++ b/policy_hal/AudioPolicyManager.cpp
@@ -780,6 +780,7 @@ status_t AudioPolicyManagerCustom::stopSource(sp<AudioOutputDescriptor> outputDe
                         outputDesc->sharesHwModuleWith(desc) &&
                         (newDevice != desc->device())) {
                         audio_devices_t dev = getNewOutputDevice(mOutputs.valueFor(curOutput), false /*fromCache*/);
+                        bool force = desc->device() != dev;
                         uint32_t delayMs;
                         if (dev == prevDevice) {
                             delayMs = 0;
@@ -788,7 +789,7 @@ status_t AudioPolicyManagerCustom::stopSource(sp<AudioOutputDescriptor> outputDe
                         }
                         setOutputDevice(desc,
                                     dev,
-                                    true,
+                                    force,
                                     delayMs);
                 }
             }


### PR DESCRIPTION
- On AudioOutput::stopSource, ignore routing calls
on an output descriptor to the same device

Change-Id: I10026d3d9147e45d3ed2b93160922bc3bb4bc2d0